### PR TITLE
Fix in contributing guideline (missing space in 'checkout') and improving changelog syntax

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ Si tienes dudas, sigue las [instrucciones de GitHub](https://help.github.com/art
 
 Para proponer cambios:
  * Asegúrate de tener tu copia local actualizada.
- * Crea una nueva rama para el cambio a proponer (`git checkout-b <nombre-de-la-rama>`).
+ * Crea una nueva rama para el cambio a proponer (`git checkout -b <nombre-de-la-rama>`).
  * Añade tus cambios utilizando [_micro commits_](https://lucasr.org/2011/01/29/micro-commits/).
  * Una vez completados tus cambios, haz _push_ a tu _fork_.
  * Finalmente, crea un [GitHub Pull Request](https://help.github.com/articles/creating-a-pull-request-from-a-fork/) desde tu fork, a través de la interfaz web de GitHub.

--- a/changelog.md
+++ b/changelog.md
@@ -7,18 +7,18 @@ This file keeps a log of version releases. This file is maintained
 
 * Each significant change should be described in the "unpublished" section
 * Entry versions should follow the following:
-** Syntax:
-*** [X.Y.Z] - YYYY-MM-DD
-** Convention:
-*** For X.Y.Z, increment the digit following this scheme:
-**** X = breaking change (previous version is now deprecated),
-**** Y = additive change (previous version is still valid),
-**** Z = just a simple patch (for a typo or error).
+  * Syntax:
+    * [X.Y.Z] - YYYY-MM-DD
+  * Convention:
+    * For X.Y.Z, increment the digit following this scheme:
+      * X = breaking change (previous version is now deprecated),
+      * Y = additive change (previous version is still valid),
+      * Z = just a simple patch (for a typo or error).
 * When a the new version is released, a new [Unreleased] section is created in the "Release Change History" below.
 
 ## Release Change History
 
-### [Unreleased] [1.0.0] (First version of the site)
+### [Unreleased] [1.0.0] - YYYY-MM-DD (First version of the site)
 
 #### Added
 

--- a/en/CONTRIBUTING.md
+++ b/en/CONTRIBUTING.md
@@ -16,7 +16,7 @@ For more information, please refer to [GitHub's instructions on this](https://he
 
 To submit changes:
  * Make sure your local copy is updated.
- * Create a dedicated branch locally (`git checkout-b <nombre-de-la-rama>`).
+ * Create a dedicated branch locally (`git checkout -b <nombre-de-la-rama>`).
  * Add your changes by creating [_micro commits_](https://lucasr.org/2011/01/29/micro-commits/).
  * Once your changes are completed, push them to your fork.
  * Finally, create a [GitHub Pull Request](https://help.github.com/articles/creating-a-pull-request-from-a-fork/) from your fork, by using GitHub's web interface.


### PR DESCRIPTION
Added missing space between 'git checkout' and  the '-b option' in both versions (Spanish and English).

Also, improved changelog syntax (nested lists and date for releases).

### Submitter checklist

- [X] Make sure your branch is updated
- [X] Read and follow the CONTRIBUTING file
- [X] Update the changelog file (if applicable)
